### PR TITLE
Update encodings and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,9 @@ easy_config |python_versions| |license| |develop_build| |develop_coverage|
 Example
 -------
 
-Here is a full working example of using easy_config. First, write your configuration class::
+Here is a full working example of using easy_config. First, write your configuration class:
+
+.. code-block:: python
 
    # config.py
    from easy_config import EasyConfig
@@ -30,14 +32,18 @@ Here is a full working example of using easy_config. First, write your configura
       name: str
       check_bounds: bool = True  # options with defaults must all come after non-default options
 
-A sample configuration file::
+A sample configuration file:
+
+.. code-block:: ini
 
    # myprogram.ini
    [MyProgram]
    # section name matches `NAME` from the configuration class
    number = 3
 
-And a sample program to illustrate the usage::
+And a sample program to illustrate the usage:
+
+.. code-block:: python
 
    # test_config.py
    import sys
@@ -46,13 +52,17 @@ And a sample program to illustrate the usage::
 
    print(MyProgramConfig.load(name=sys.argv[1])
 
-Running this program with various options::
+Running this program with various options:
+
+.. code-block:: bash
 
    $ python test_config.py Scott
    MyProgramConfig(number=3, name='Scott', check_bounds=True)
+
    $ env MYPROGRAM_CHECK_BOUNDS=False python test_config.py Scott
    # environment variable names are the all-uppercase transformation of the NAME concatenated with the option name and an underscore
    MyProgramConfig(number=3, name='Scott', check_bounds=False)
+
    $ env MYPROGRAM_NUMBER=10 MYPROGRAM_NAME=Charlie python test_config.py Scott
    MyProgramConfig(number=10, name='Scott', check_bounds=True)
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 easy_config |python_versions| |license| |develop_build| |develop_coverage|
 ==========================================================================
 
-.. |python_versions| image:: https://img.shields.io/badge/python->%3D3.7-blue.svg?style=flat-square
-    :alt: Supports Python 3.7 and later
+.. |python_versions| image:: https://img.shields.io/badge/python->%3D3.6-blue.svg?style=flat-square
+    :alt: Supports Python 3.6 and later
 .. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square
     :target: LICENSE.rst
     :alt: MIT License

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: POSIX
     Programming Language :: Python
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3 :: Only
     Topic :: Utilities

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Setup module for the easy_config package."""
 
 import setuptools

--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Parse configuration values from files, the environment, and elsewhere all in one place."""
 
 import configparser

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
+# -*- coding: utf-8 -*-
+
 """Tests for easy_config."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Test configuration module for easy_config."""
 
 import os

--- a/tests/test_easy_config.py
+++ b/tests/test_easy_config.py
@@ -1,4 +1,7 @@
+# -*- coding: utf-8 -*-
+
 """Tests for the EasyConfig class."""
+
 from io import StringIO
 
 import pytest


### PR DESCRIPTION
- Add `# -*- coding: utf-8 -*-` to first line of all python files
- Update documentation for poor suckers still on py36