### PR TITLE
Add config_command to click contribution

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -208,7 +208,10 @@ autodoc_member_order = 'bysource'
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'click': ('http://click.pocoo.org/latest/', None),
+}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/docs/source/contrib/click.rst
+++ b/docs/source/contrib/click.rst
@@ -1,0 +1,4 @@
+Click
+=====
+.. automodule:: easy_config.contrib.click
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,20 +1,13 @@
-.. easy_config documentation master file, created by
-   sphinx-quickstart on Wed Sep 26 22:42:39 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to easy_config's documentation!
 =======================================
-
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
-
+   reference
+   contrib/click
 
 Indices and tables
 ==================
-
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1,0 +1,4 @@
+Reference
+=========
+.. automodule:: easy_config
+   :members:

--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -167,32 +167,6 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
         }
 
     @classmethod
-    def _load_helper(
-            cls: Type[EasyConfigOrSubclass],
-            _additional_files: Optional[Iterable[Union[str, Path, TextIO]]] = None,
-            *,
-            _parse_files: bool = True,
-            _parse_environment: bool = True,
-            _lookup_config_envvar: Optional[str] = None,
-            **kwargs: Any,
-    ) -> Iterable[Dict[str, Any]]:
-        if _parse_files and cls.FILES:
-            for file_paths in cls.FILES:
-                yield cls._load_file(file_paths)
-        if _additional_files:
-            for files in _additional_files:
-                yield cls._load_file(files)
-        if _lookup_config_envvar is not None:
-            envvar = f'{cls.NAME.upper()}_{_lookup_config_envvar.upper()}'
-            file_name = os.environ.get(envvar)
-            if file_name:
-                yield cls._load_file(file_name)
-        if _parse_environment:
-            yield cls._load_environment()
-
-        yield cls._load_dict(kwargs)
-
-    @classmethod
     def load(
         cls: Type[EasyConfigOrSubclass],
         _additional_files: Optional[Iterable[Union[str, Path, TextIO]]] = None,

--- a/src/easy_config/contrib/click.py
+++ b/src/easy_config/contrib/click.py
@@ -11,7 +11,7 @@ from easy_config import EasyConfig
 
 __all__ = [
     'args_from_config',
-    'config_command',
+    'easy_config_option',
 ]
 
 # declaring types for the decorator
@@ -23,37 +23,23 @@ Func2Type = Callable[[EasyConfig], Any]
 G = TypeVar('G', bound=Func2Type)
 
 
-def args_from_config(cls: Type[EasyConfig]) -> Callable[[F], F]:  # noqa: D202
-    """Build a decorator based on the given easy config class."""
-
-    def decorate(command: F) -> F:
-        """Decorate the :mod:`click` command."""
-        for field in dataclasses.fields(cls):
-            if field.default is dataclasses.MISSING:
-                wrapper = click.argument(field.name, type=field.type)
-            else:
-                wrapper = click.option(
-                    f'--{field.name}', type=field.type, default=field.default, show_default=True
-                )
-
-            command = wrapper(command)
-
-        return command
-
-    return decorate
-
-
-def config_command(cls: Type[EasyConfig]) -> Callable[[G], F]:  # noqa: D202
+def easy_config_option(cls: Type[EasyConfig], prompt: bool = False) -> Callable[[G], F]:  # noqa: D202
     """Build a decorator based on the given easy config class.
 
+    :param cls: An EasyConfig class
+    :param prompt: If true, adds prompts to the resulting CLI for all fields.
+
     This makes it possible to automatically generate the :py:func:`click.argument` and :py:func:`click.option` entries
-    for a command for a given :py:class:`EasyConfig` class. For example, if you have a python file called ``main.py``:
+    for a command for a given :py:class:`easy_config.EasyConfig` class. For example, if you have a python file called
+    ``main.py``:
 
     .. code-block:: python
 
+        # main.py
+
         import click
         from easy_config import EasyConfig
-        from easy_config.contrib.click import config_command
+        from easy_config.contrib.click import easy_config_option
 
         class ExampleConfig(EasyConfig):
             FILES = None
@@ -63,8 +49,10 @@ def config_command(cls: Type[EasyConfig]) -> Callable[[G], F]:  # noqa: D202
             floaty_number: float = 5.0
 
         @click.command()
-        @config_command(ExampleConfig)
+        @easy_config_option(ExampleConfig)
         def main(example_config: ExampleConfig):
+            click.echo()
+            click.echo('RESULTS')
             click.echo(f'number: {example_config.number}')
             click.echo(f'floaty_number: {example_config.floaty_number}')
 
@@ -75,23 +63,112 @@ def config_command(cls: Type[EasyConfig]) -> Callable[[G], F]:  # noqa: D202
 
     .. code-block:: sh
 
-        Usage: scratch.py [OPTIONS] NUMBER
+        Usage: main.py [OPTIONS] NUMBER
 
           Apply the keyword arguments to the EasyConfig class.
 
         Options:
-          --floaty_number FLOAT
+          --floaty_number FLOAT  [default: 5.0]
           --help                 Show this message and exit.
+
+    Modifying the code slightly to use ``@easy_config_option(ExampleConfig, prompt=True)`` will give the following CLI:
+
+    .. code-block:: sh
+
+        Usage: main.py [OPTIONS]
+
+          Apply the keyword arguments to the EasyConfig class.
+
+        Options:
+          --floaty_number FLOAT  [default: 5.0]
+          --number INTEGER
+          --help                 Show this message and exit.
+
+    An example run might look like:
+
+    .. code-block:: sh
+
+        $ python main.py
+        Floaty number [5.0]:
+        Number: 5
+
+        RESULTS
+        number: 5
+        floaty_number: 5.0
+
+        Process finished with exit code 0
+
+    Custom prompt messages can be prepended by adding a `doc` entry to the `metadata` dictionary in each
+    :py:func:`dataclasses.field` as in:
+
+    .. code-block:: python
+
+        # main.py
+
+        from dataclasses import field
+        import click
+        from easy_config import EasyConfig
+        from easy_config.contrib.click import easy_config_option
+
+        class ExampleConfig(EasyConfig):
+            FILES = None
+            NAME = 'MyProgram'
+
+            number: int = field(metadata={'doc': 'A number'})
+            floaty_number: float = field(5.0, metadata={'doc': 'A floating point number'})
     """
 
     def decorate(command: G) -> F:  # noqa: D202
         """Decorate the :mod:`click` command."""
 
-        @args_from_config(cls)
+        @args_from_config(cls, prompt=prompt)
         def inner_decorate(**kwargs: Any) -> Any:
             """Apply the keyword arguments to the EasyConfig class."""
             return command(cls.load(**kwargs))
 
         return inner_decorate  # type: ignore
+
+    return decorate
+
+
+def args_from_config(cls: Type[EasyConfig], prompt: bool = False) -> Callable[[F], F]:  # noqa: D202
+    """Build a decorator based on the given easy config class.
+
+    :param cls: An EasyConfig class
+    :param prompt: If true, adds prompts to the resulting CLI for all fields.
+    """
+
+    def decorate(command: F) -> F:
+        """Decorate the :mod:`click` command."""
+        for field in reversed(dataclasses.fields(cls)):
+            if prompt:
+                doc = field.metadata.get('doc') if field.metadata is not None else None
+                if doc is not None:
+                    prompt_text = f'{doc.rstrip(".")}.\n{field.name.replace("_", " ").capitalize()}'
+                else:
+                    prompt_text = True  # type: ignore
+
+                wrapper = click.option(
+                    f'--{field.name}',
+                    type=field.type,
+                    prompt=prompt_text,
+                    default=None if field.default is dataclasses.MISSING else field.default,
+                    show_default=field.default is not dataclasses.MISSING,
+                )
+
+            elif field.default is dataclasses.MISSING:
+                wrapper = click.argument(field.name, type=field.type)
+
+            else:
+                wrapper = click.option(
+                    f'--{field.name}',
+                    type=field.type,
+                    default=field.default,
+                    show_default=True,
+                )
+
+            command = wrapper(command)  # type: ignore
+
+        return command
 
     return decorate

--- a/src/easy_config/contrib/click.py
+++ b/src/easy_config/contrib/click.py
@@ -19,7 +19,7 @@ __all__ = [
 FuncType = Callable[..., Any]
 F = TypeVar('F', bound=FuncType)
 
-Func2Type = Callable[[Type[EasyConfig]], Any]
+Func2Type = Callable[[EasyConfig], Any]
 G = TypeVar('G', bound=Func2Type)
 
 
@@ -41,10 +41,10 @@ def args_from_config(cls: Type[EasyConfig]) -> Callable[[F], F]:  # noqa: D202
     return decorate
 
 
-def config_command(cls: Type[EasyConfig]) -> Callable[[G], G]:  # noqa: D202
+def config_command(cls: Type[EasyConfig]) -> Callable[[G], F]:  # noqa: D202
     """Build a decorator based on the given easy config class."""
 
-    def decorate(command: G) -> G:  # noqa: D202
+    def decorate(command: G) -> F:  # noqa: D202
         """Decorate the :mod:`click` command."""
 
         @args_from_config(cls)
@@ -52,6 +52,6 @@ def config_command(cls: Type[EasyConfig]) -> Callable[[G], G]:  # noqa: D202
             """Apply the keyword arguments to the EasyConfig class."""
             return command(cls.load(**kwargs))
 
-        return inner_decorate
+        return inner_decorate  # type: ignore
 
     return decorate

--- a/src/easy_config/contrib/click.py
+++ b/src/easy_config/contrib/click.py
@@ -42,7 +42,45 @@ def args_from_config(cls: Type[EasyConfig]) -> Callable[[F], F]:  # noqa: D202
 
 
 def config_command(cls: Type[EasyConfig]) -> Callable[[G], F]:  # noqa: D202
-    """Build a decorator based on the given easy config class."""
+    """Build a decorator based on the given easy config class.
+
+    This makes it possible to automatically generate the :py:func:`click.argument` and :py:func:`click.option` entries
+    for a command for a given :py:class:`EasyConfig` class. For example, if you have a python file called ``main.py``:
+
+    .. code-block:: python
+
+        import click
+        from easy_config import EasyConfig
+        from easy_config.contrib.click import config_command
+
+        class ExampleConfig(EasyConfig):
+            FILES = None
+            NAME = 'MyProgram'
+
+            number: int
+            floaty_number: float = 5.0
+
+        @click.command()
+        @config_command(ExampleConfig)
+        def main(example_config: ExampleConfig):
+            click.echo(f'number: {example_config.number}')
+            click.echo(f'floaty_number: {example_config.floaty_number}')
+
+        if __name__ == '__main__':
+            main()
+
+    And run it with ``python main.py``, you will get:
+
+    .. code-block:: sh
+
+        Usage: scratch.py [OPTIONS] NUMBER
+
+          Apply the keyword arguments to the EasyConfig class.
+
+        Options:
+          --floaty_number FLOAT
+          --help                 Show this message and exit.
+    """
 
     def decorate(command: G) -> F:  # noqa: D202
         """Decorate the :mod:`click` command."""

--- a/src/easy_config/contrib/click.py
+++ b/src/easy_config/contrib/click.py
@@ -11,12 +11,16 @@ from easy_config import EasyConfig
 
 __all__ = [
     'args_from_config',
+    'config_command',
 ]
 
 # declaring types for the decorator
 # https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 FuncType = Callable[..., Any]
 F = TypeVar('F', bound=FuncType)
+
+Func2Type = Callable[[Type[EasyConfig]], Any]
+G = TypeVar('G', bound=Func2Type)
 
 
 def args_from_config(cls: Type[EasyConfig]) -> Callable[[F], F]:  # noqa: D202
@@ -33,5 +37,21 @@ def args_from_config(cls: Type[EasyConfig]) -> Callable[[F], F]:  # noqa: D202
             command = wrapper(command)
 
         return command
+
+    return decorate
+
+
+def config_command(cls: Type[EasyConfig]) -> Callable[[G], G]:  # noqa: D202
+    """Build a decorator based on the given easy config class."""
+
+    def decorate(command: G) -> G:  # noqa: D202
+        """Decorate the :mod:`click` command."""
+
+        @args_from_config(cls)
+        def inner_decorate(**kwargs: Any) -> Any:
+            """Apply the keyword arguments to the EasyConfig class."""
+            return command(cls.load(**kwargs))
+
+        return inner_decorate
 
     return decorate

--- a/tests/test_contrib_click.py
+++ b/tests/test_contrib_click.py
@@ -6,7 +6,7 @@ import click
 from click.testing import CliRunner
 
 from easy_config import EasyConfig
-from easy_config.contrib.click import args_from_config
+from easy_config.contrib.click import args_from_config, config_command
 
 
 def test_option():  # noqa: D202
@@ -23,6 +23,7 @@ def test_option():  # noqa: D202
     @click.command()
     @args_from_config(ExampleConfig)
     def main(number):
+        """Print the example configuration."""
         click.echo(f'number: {number}')
 
     runner = CliRunner()
@@ -47,6 +48,7 @@ def test_argument():  # noqa: D202
     @click.command()
     @args_from_config(ExampleConfig)
     def main(number):
+        """Print the example configuration."""
         click.echo(f'number: {number}')
 
     runner = CliRunner()
@@ -69,8 +71,33 @@ def test_mixed():  # noqa: D202
     @click.command()
     @args_from_config(ExampleConfig)
     def main(number, floaty_number):
+        """Print the example configuration."""
         click.echo(f'number: {number}')
         click.echo(f'floaty_number: {floaty_number}')
+
+    runner = CliRunner()
+    result = runner.invoke(main, ['4'])
+    assert result.output == 'number: 4\nfloaty_number: 5.0\n'
+
+
+def test_pos_arg():  # noqa: D202
+    """Test building a config object for function."""
+
+    class ExampleConfig(EasyConfig):
+        """Example EasyConfig subclass to test with."""
+
+        FILES = None
+        NAME = 'MyProgram'
+
+        number: int
+        floaty_number: float = 5.0
+
+    @click.command()
+    @config_command(ExampleConfig)
+    def main(example_config: ExampleConfig):
+        """Print the example configuration."""
+        click.echo(f'number: {example_config.number}')
+        click.echo(f'floaty_number: {example_config.floaty_number}')
 
     runner = CliRunner()
     result = runner.invoke(main, ['4'])

--- a/tests/test_contrib_click.py
+++ b/tests/test_contrib_click.py
@@ -2,11 +2,13 @@
 
 """Test the easy_config :mod:`click` wrapper."""
 
+from dataclasses import field
+
 import click
 from click.testing import CliRunner
 
 from easy_config import EasyConfig
-from easy_config.contrib.click import args_from_config, config_command
+from easy_config.contrib.click import args_from_config, easy_config_option
 
 
 def test_option():  # noqa: D202
@@ -93,7 +95,7 @@ def test_pos_arg():  # noqa: D202
         floaty_number: float = 5.0
 
     @click.command()
-    @config_command(ExampleConfig)
+    @easy_config_option(ExampleConfig)
     def main(example_config: ExampleConfig):
         """Print the example configuration."""
         click.echo(f'number: {example_config.number}')
@@ -102,3 +104,27 @@ def test_pos_arg():  # noqa: D202
     runner = CliRunner()
     result = runner.invoke(main, ['4'])
     assert result.output == 'number: 4\nfloaty_number: 5.0\n'
+
+
+def test_prompt():  # noqa: D202
+    """Test building a config object for function."""
+
+    class ExampleConfig(EasyConfig):
+        """Example EasyConfig subclass to test with."""
+
+        FILES = None
+        NAME = 'MyProgram'
+
+        number: int = field(metadata={'doc': 'A number'})
+        floaty_number: float = 5.0
+
+    @click.command()
+    @easy_config_option(ExampleConfig, prompt=True)
+    def main(example_config: ExampleConfig):
+        """Print the example configuration."""
+        click.echo(f'number: {example_config.number}')
+        click.echo(f'floaty_number: {example_config.floaty_number}')
+
+    runner = CliRunner()
+    result = runner.invoke(main, input='2\n\n')
+    assert result.output == 'A number.\nNumber: 2\nFloaty number [5.0]: \nnumber: 2\nfloaty_number: 5.0\n'


### PR DESCRIPTION
This command makes it possible to decorate a click function and just have it take in an instance of the configuration.

### To Do:

- [x] Better documentation of usage of this command (and the other click extension, so as to avoid confusion)
- [x] Consider adding ability to mix other click options
- [x] Fix static type annotations for MyPy