### PR TITLE
Better handling of type coercion errors in values.

### DIFF
--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -128,7 +128,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
             except (configparser.NoSectionError, configparser.NoOptionError):
                 pass
             except (TypeError, ValueError) as e:
-                raise ConfigValueCoercionError(f'While reading the configuration file `{config_file if given_path else "UNKNWON"}`, could not coerce value for field `{field.name}` to type `{field.type}`') from e
+                raise ConfigValueCoercionError(f'While reading the configuration file `{config_file if given_path else "<UNKNOWN>"}`, could not coerce value for field `{field.name}` to type `{field.type}`') from e
 
         return values
 

--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -101,6 +101,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
         which includes open files and TextIO objects.
 
         :returns: a mapping from string configuration value names to their values
+        :raises ConfigValueCoercionError: when an error occurs calling the type constructor on an input value
         """
         config = configparser.ConfigParser()
         if isinstance(config_file, (str, Path, os.PathLike)):
@@ -142,6 +143,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
         environment variable "MYPROGRAM_NUMBER".
 
         :returns: a mapping from string configuration value names to their values
+        :raises ConfigValueCoercionError: when an error occurs calling the type constructor on an input value
         """
         values = {}
         for field in dataclasses.fields(cls):
@@ -171,6 +173,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
 
         :param d: the input mapping of string configuration value names to their values
         :returns: a mapping from string configuration value names to their values
+        :raises ConfigValueCoercionError: when an error occurs calling the type constructor on an input value
         """
         values = {}
         for field in dataclasses.fields(cls):

--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -177,11 +177,11 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
         """
         values = {}
         for field in dataclasses.fields(cls):
-            try:
-                if field.name in d:
+            if field.name in d:
+                try:
                     values[field.name] = field.type(d[field.name])
-            except (TypeError, ValueError) as e:
-                raise ConfigValueCoercionError(f'While reading a dictionary, could not coerce value for field `{field.name}` to type `{field.type}`') from e
+                except (TypeError, ValueError) as e:
+                    raise ConfigValueCoercionError(f'While reading a dictionary, could not coerce value for field `{field.name}` to type `{field.type}`') from e
 
         return values
 

--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -49,8 +49,6 @@ class ConfigValueCoercionError(ValueError):
     Example: field type is ``int`` and the value is ``None`` or ``'apple'``.
     """
 
-    pass
-
 
 class _InheritDataclassForConfig(type):
     REQUIRED_CLASS_VARIABLES = ['FILES', 'NAME']

--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -129,7 +129,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
             except (configparser.NoSectionError, configparser.NoOptionError):
                 pass
             except (TypeError, ValueError) as e:
-                raise ConfigValueCoercionError(f'While reading the configuration file `{config_file if given_path else "UNKNWON"}`, could not coerce value for field `{field.name}` to type `{field.type}`')
+                raise ConfigValueCoercionError(f'While reading the configuration file `{config_file if given_path else "UNKNWON"}`, could not coerce value for field `{field.name}` to type `{field.type}`') from e
 
         return values
 

--- a/src/easy_config/__init__.py
+++ b/src/easy_config/__init__.py
@@ -106,8 +106,10 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
         """
         config = configparser.ConfigParser()
         if isinstance(config_file, (str, Path, os.PathLike)):
+            given_path = True
             config.read(config_file)
         else:
+            given_path = False
             config.read_file(config_file)
 
         values = {}
@@ -127,7 +129,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
             except (configparser.NoSectionError, configparser.NoOptionError):
                 pass
             except (TypeError, ValueError) as e:
-                raise ConfigValueCoercionError(f'Could not coerce value for field `{field.name}` to type `{field.type}`') from e
+                raise ConfigValueCoercionError(f'While reading the configuration file `{config_file if given_path else "UNKNWON"}`, could not coerce value for field `{field.name}` to type `{field.type}`')
 
         return values
 
@@ -156,7 +158,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
             except KeyError:  # the variable was not in the environment
                 pass
             except (TypeError, ValueError) as e:
-                raise ConfigValueCoercionError(f'Could not coerce value for field `{field.name}` to type `{field.type}`') from e
+                raise ConfigValueCoercionError(f'While reading environment variable `{prefixed_field_name}`, could not coerce value for field `{field.name}` to type `{field.type}`') from e
 
         return values
 
@@ -178,7 +180,7 @@ class EasyConfig(metaclass=_InheritDataclassForConfig):
                 if field.name in d:
                     values[field.name] = field.type(d[field.name])
             except (TypeError, ValueError) as e:
-                raise ConfigValueCoercionError(f'Could not coerce value for field `{field.name}` to type `{field.type}`') from e
+                raise ConfigValueCoercionError(f'While reading a dictionary, could not coerce value for field `{field.name}` to type `{field.type}`') from e
 
         return values
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,19 @@ def example_ini(tmpdir_factory) -> Path:
     return Path(example_ini_path)
 
 
+@pytest.fixture(scope='session')
+def bad_typed_ini(tmpdir_factory) -> Path:
+    """Create an example INI configuration file with a wrong-typed value.
+
+    :returns: the path to the example INI
+    """
+    example_ini_contents = """[MyProgram]\nnumber = apple"""
+    example_ini_path = tmpdir_factory.mktemp('config').join('bad_typed.ini')
+    with open(example_ini_path, 'w') as f:
+        f.write(example_ini_contents)
+    return Path(example_ini_path)
+
+
 @pytest.fixture(scope='function')
 def example_env():
     """Add example values to the environment."""
@@ -29,6 +42,14 @@ def example_env():
     yield  # cleanup of new environment variables is necessary
     del os.environ['MYPROGRAM_NUMBER']
     del os.environ['MYPROGRAM_FLAG']
+
+
+@pytest.fixture(scope='function')
+def bad_typed_env():
+    """Add a badly typed value to the environment."""
+    os.environ['MYPROGRAM_NUMBER'] = 'apple'
+    yield
+    del os.environ['MYPROGRAM_NUMBER']
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_easy_config.py
+++ b/tests/test_easy_config.py
@@ -7,7 +7,7 @@ from io import StringIO
 
 import pytest
 
-from easy_config import EasyConfig
+from easy_config import ConfigValueCoercionError, EasyConfig
 
 
 class ExampleConfig(EasyConfig):
@@ -113,6 +113,18 @@ def test_load_from_env_missing(example_config_env_missing):
 def test_read_dict():
     """Test EasyConfig._read_dict."""
     assert ExampleConfig._read_dict({'number': '3', 'unused': 'foo'}) == {'number': 3}
+
+
+def test_bad_reads(bad_typed_ini, bad_typed_env):
+    """Test EasyConfig._read_* methods with bad (wrongly typed) input values."""
+    with pytest.raises(ConfigValueCoercionError):
+        ExampleConfig._read_file(bad_typed_ini)
+
+    with pytest.raises(ConfigValueCoercionError):
+        ExampleConfig._read_environment()
+
+    with pytest.raises(ConfigValueCoercionError):
+        ExampleConfig._read_dict({'number': 'apple'})
 
 
 def test_load(example_ini, example_env):

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,6 +1,8 @@
 example_env  # unused function (tests/conftest.py:22)
 example_env  # unused variable (tests/test_easy_config.py:47)
 example_env  # unused variable (tests/test_easy_config.py:57)
+bad_typed_env  # unused function (tests/conftest.py:47)
+bad_typed_env  # unused variable (tests/test_easy_config.py:118)
 example_config_env  # unused function (tests/conftest.py:35)
 example_config_env  # unused variable (tests/test_easy_config.py:51)
 example_config_env_empty  # unused function (tests/conftest.py:42)


### PR DESCRIPTION
Will close #18.

Add `ConfigValueCoercionError`.
Raise this new error from places where coercion using type constructors is being used.

Need to add tests.

@cthoyt what do you think of this design?